### PR TITLE
chore: Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @s-takayanagi-incudata @mkohei


### PR DESCRIPTION
Allow only codeowner to do a pull request merge of the main branch.

The default access permission is "Write".
Detail: https://github.com/incudata-loghy/loghy-sample/settings/role_details